### PR TITLE
removes duplicate sound `block.sculk_jaw.break`

### DIFF
--- a/common/src/main/resources/assets/deeperdarker/sounds.json
+++ b/common/src/main/resources/assets/deeperdarker/sounds.json
@@ -97,16 +97,6 @@
       "deeperdarker:block/sculk_jaw/step5"
     ]
   },
-  "block.sculk_jaw.break": {
-    "subtitle": "subtitles.block.generic.break",
-    "sounds": [
-      "deeperdarker:block/sculk_jaw/break1",
-      "deeperdarker:block/sculk_jaw/break2",
-      "deeperdarker:block/sculk_jaw/break3",
-      "deeperdarker:block/sculk_jaw/break4",
-      "deeperdarker:block/sculk_jaw/break5"
-    ]
-  },
   "block.sculk_stone.fall": {
     "sounds": [
       "deeperdarker:block/sculk_stone/step1",


### PR DESCRIPTION
fixes:
```
[Worker-Main6/WARN] [net.minecraft.client.sounds.SoundManager/]: Invalid sounds.json in resourcepack: 'Mod Resources'
com.google.gson.JsonSyntaxException: duplicate key: block.sculk_jaw.break
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:190) ~[gson-2.8.9.jar%23121!/:?]
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:145) ~[gson-2.8.9.jar%23121!/:?]
	at net.minecraft.util.GsonHelper.m_13771_(GsonHelper.java:521) ~[client-1.19.2-20220805.130853-srg.jar%23479!/:?]
	at net.minecraft.util.GsonHelper.m_13767_(GsonHelper.java:539) ~[client-1.19.2-20220805.130853-srg.jar%23479!/:?]
	at net.minecraft.client.sounds.SoundManager.m_5944_(SoundManager.java:68) ~[client-1.19.2-20220805.130853-srg.jar%23479!/:?]
	at net.minecraft.client.sounds.SoundManager.m_5944_(SoundManager.java:38) ~[client-1.19.2-20220805.130853-srg.jar%23479!/:?]
	at net.minecraft.server.packs.resources.SimplePreparableReloadListener.m_10786_(SimplePreparableReloadListener.java:11) ~[client-1.19.2-20220805.130853-srg.jar%23479!/:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) [?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) [?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) [?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) [?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) [?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) [?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) [?:?]
```