### PR TITLE
Simplify ContainerOpenersCounter Mixin for Mod Compatability

### DIFF
--- a/common/src/main/java/com/kyanite/deeperdarker/mixin/containers/ChestEntityMixin.java
+++ b/common/src/main/java/com/kyanite/deeperdarker/mixin/containers/ChestEntityMixin.java
@@ -1,54 +1,25 @@
 package com.kyanite.deeperdarker.mixin.containers;
 
+import com.kyanite.deeperdarker.DeeperAndDarker;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.ContainerOpenersCounter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ContainerOpenersCounter.class)
 public abstract class ChestEntityMixin {
-    @Shadow
-    private int openCount;
-
-    @Shadow
-    protected static void scheduleRecheck(Level pLevel, BlockPos pPos, BlockState pState) {
-    }
-
-    @Shadow
-    protected abstract int getOpenCount(Level pLevel, BlockPos pPos);
-
-    @Shadow
-    protected abstract void onOpen(Level pLevel, BlockPos pPos, BlockState pState);
-
-    @Shadow
-    protected abstract void onClose(Level pLevel, BlockPos pPos, BlockState pState);
-
-    @Shadow
-    protected abstract void openerCountChanged(Level pLevel, BlockPos pPos, BlockState pState, int pCount, int pOpenCount);
-
-    @Inject(method = "recheckOpeners", at = @At("HEAD"), cancellable = true)
-    public void recheckOpen(Level pLevel, BlockPos pPos, BlockState pState, CallbackInfo ci) {
+    @Inject(method = "recheckOpeners",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/ContainerOpenersCounter;openerCountChanged(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)V"),
+            cancellable = true)
+    public void beforeOpenerCountChanged(Level pLevel, BlockPos pPos, BlockState pState, CallbackInfo ci) {
         ci.cancel();
-        int i = this.getOpenCount(pLevel, pPos);
-        int j = this.openCount;
-        if(j != i) {
-            boolean flag = i != 0;
-            boolean flag1 = j != 0;
-            if(flag && !flag1) {
-                this.onOpen(pLevel, pPos, pState);
-                pLevel.gameEvent(null, GameEvent.CONTAINER_OPEN, pPos);
-            } else if(!flag) {
-                this.onClose(pLevel, pPos, pState);
-                pLevel.gameEvent(null, GameEvent.CONTAINER_CLOSE, pPos);
-            }
-
-            this.openCount = i;
-        }
     }
 }


### PR DESCRIPTION
Hello!

I'm the developer of ImmersiveMC, and I currently rely on a Mixin into the first line of `recheckOpeners`, a mixin you entirely redirect for functionality. It looks like though you rewrite a lot of vanilla Minecraft's code in the redirect (or more precisely, the injection followed by cancel), including the few lines I do actually need to change!

In short, this PR vastly simplifies the mixin for you **without changing functionality**, while still allowing my mod to work. It does so by injecting immediately before the first line of code not copy-pasted into the original mixin and cancelling at that point.

More information on my mod and why this mod conflict occurs:

One of the features of my mod is that users can interact with chests without opening the UI. As such, in order to keep the chest lid open, I need to adjust the value of `i`/the first `int` in `recheckOpeners` to add all of the members of my mod who are interacting with the chest without the UI.

The issue is your mod injects into the same function before I do and you cancel the rest of the function and redirects execution. As a result, I can't get my injected value into `i`, so the chest lid closes, thus making it not ideal for my users to interact with the chest.

Thank you for taking the time to read this PR! I apologize if I've come off as insulting or something else negative throughout this, I genuinely do not intend to. I look forward to hearing back on this PR! :smile:

EDIT: To clarify, I would inject into `getOpenCount()` (the function that's used to set `i`), however I can't, as a library used in a few mods redirects execution for that method, running an entirely different piece of code, so that's sadly not an option for me.