### PR TITLE
Fix sculk snapper code for when they are tamed

### DIFF
--- a/common/src/main/java/com/kyanite/deeperdarker/registry/entities/custom/SculkSnapperEntity.java
+++ b/common/src/main/java/com/kyanite/deeperdarker/registry/entities/custom/SculkSnapperEntity.java
@@ -133,7 +133,7 @@ public class SculkSnapperEntity extends ActionAnimatedEntity implements IAnimata
 
         if(this.isTame() && this.getOwner() != null) {
             if(this.getOwner().distanceTo(this) < 13 && this.getRandom().nextInt(0, 1100) == 0) {
-                List<Enchantment> enchantments = (List<Enchantment>) Registry.ENCHANTMENT_REGISTRY;
+                List<Enchantment> enchantments = Registry.ENCHANTMENT.stream().toList();
                 int randomIndex = this.getRandom().nextInt(enchantments.size());
                 Enchantment randomEnchantment = enchantments.get(randomIndex);
                 EnchantmentInstance instance = new EnchantmentInstance(randomEnchantment, 1);

--- a/common/src/main/java/com/kyanite/deeperdarker/registry/entities/custom/SculkSnapperEntity.java
+++ b/common/src/main/java/com/kyanite/deeperdarker/registry/entities/custom/SculkSnapperEntity.java
@@ -131,8 +131,8 @@ public class SculkSnapperEntity extends ActionAnimatedEntity implements IAnimata
     public void tick() {
         super.tick();
 
-        if(this.isTame() && this.getOwner().distanceTo(this) < 13) {
-            if(this.getRandom().nextInt(0, 1100) == 0) {
+        if(this.isTame() && this.getOwner() != null) {
+            if(this.getOwner().distanceTo(this) < 13 && this.getRandom().nextInt(0, 1100) == 0) {
                 List<Enchantment> enchantments = (List<Enchantment>) Registry.ENCHANTMENT_REGISTRY;
                 int randomIndex = this.getRandom().nextInt(enchantments.size());
                 Enchantment randomEnchantment = enchantments.get(randomIndex);


### PR DESCRIPTION
This is only a small workaround for the issue where the ActionAnimatedEntity because it never sets an owner nor has an owner function, it causes the server to crash whenever a sculk snapper is presented, using this check to see if the owner is null is only to prevent servers from crashing.

Fixes [#122](https://github.com/KyaniteMods/DeeperAndDarker/issues/122)