### PR TITLE
Fixed SculkTransmitterItem.java

### DIFF
--- a/src/main/java/com/kyanite/deeperdarker/content/items/SculkTransmitterItem.java
+++ b/src/main/java/com/kyanite/deeperdarker/content/items/SculkTransmitterItem.java
@@ -96,7 +96,7 @@ public class SculkTransmitterItem extends Item {
 
         MenuProvider menu = level.getBlockState(linkedBlockPos).getMenuProvider(level, linkedBlockPos);
         if(menu != null) {
-            if(level.isClientSide())
+            if(!level.isClientSide())
                 player.playNotifySound(DDSounds.TRANSMITTER_OPEN, SoundSource.PLAYERS, 1.0f, 1.0f);
             player.openMenu(menu);
             if(level.getBlockEntity(linkedBlockPos) instanceof ChestBlockEntity chestBlockEntity) chestBlockEntity.startOpen(player);


### PR DESCRIPTION
- Fixed custom names causing crash when hovered or used
- Fixed custom names being removed when unlinking
- Fixed sounds doubling when used
- Fixed linked block name being "air" when chunk is not loaded on the client
- Removed clientside error "not_found" when the chunk is not loaded in the client, but is loaded on the server