### PR TITLE
Fix empty bucket item stack

### DIFF
--- a/src/main/java/com/kyanite/deeperdarker/content/entities/AnglerFish.java
+++ b/src/main/java/com/kyanite/deeperdarker/content/entities/AnglerFish.java
@@ -91,7 +91,7 @@ public class AnglerFish extends AbstractFish {
 
     @Override
     public ItemStack getBucketItemStack() {
-        return null;
+        return ItemStack.EMPTY;
     }
 
     static class AnglerFishAttackGoal extends MeleeAttackGoal {


### PR DESCRIPTION
Supplementaries mod has an issue with null values - https://github.com/MehVahdJukaar/Supplementaries/blob/1.20/common/src/main/java/net/mehvahdjukaar/supplementaries/common/misc/mob_container/BucketHelper.java#L78

[crash-2025-08-27_04.04.40-client.txt](https://github.com/user-attachments/files/22030236/crash-2025-08-27_04.04.40-client.txt)
